### PR TITLE
chore: rename repo name references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,62 @@
+---
+name: "\U0001F41B Bug report"
+about: Report an issue with @shopify/react-native-performance to help us improve
+labels: 'bug'
+
+---
+
+Thanks for taking the time to fill out this bug report!
+
+If this is not a bug report, please use other relevant channels:
+- [Create a feature proposal on Discussions](https://github.com/Shopify/react-native-performance-open-source/discussions/new)
+- [Chat with others in the #react-native-performance channel on Shopify React Native Open Source Discord](https://discord.com/channels/928252803867107358/928253059375726622)
+
+Before you proceed:
+
+- Make sure you are on latest versions of React Native Performance packages and their dependencies.
+- If you are having an issue with your machine or build tools, the issue belongs on another repository as that is outside of the scope of React Native Performance.
+
+## Current behavior
+What code are you running and what is happening? Include a screenshot or video if it's a UI related issue.
+
+## Expected behavior
+
+What do you expect to happen instead?
+
+## To Reproduce
+You must provide a way to reproduce the problem. Use the fixture app to create an example that reproduces the bug and provide a link to a GitHub repository under your username.
+
+## Platform:
+ - [] iOS
+ - [] Android
+
+## Packages
+Which packages are affected by the issue?
+- [] @shopify/react-native-performance
+- [] @shopify/react-native-performance-lists-profiler
+- [] @shopify/flipper-plugin-react-native-performance
+- [] @shopify/react-native-performance-navigation
+- [] @shopify/react-native-performance-navigation-bottom-tabs
+- [] @shopify/react-native-performance-navigation-drawer
+
+## Environment
+What are the exact versions of packages that you are using?
+
+When filling the table below, please remove the packages that you're not using.
+
+- [] I've removed the packages that I don't use
+
+| package                                | version         |
+| -------------------------------------- | --------------- |
+| @shopify/react-native-performance                        |
+| @shopify/react-native-performance-lists-profiler         |
+| @shopify/flipper-plugin-react-native-performance         |
+| @shopify/react-native-performance-navigation             |
+| @shopify/react-native-performance-navigation-bottom-tabs |
+| @shopify/react-native-performance-navigation-drawer      |
+| @react-navigation/native                                 |
+| @react-navigation/bottom-tabs                            |
+| @react-navigation/drawer                                 |
+| @react-navigation/stack                                  |
+| react-native                                             |
+| node                                                     |

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://react-native-performance.docs.shopify.io/
+    about: Read the official documentation.
+  - name: Feature proposals
+    url: https://github.com/Shopify/react-native-performance-open-source/discussions
+    about: Post a feature proposal on Discussions.
+  - name: Discussions
+    url: https://github.com/Shopify/react-native-performance-open-source/discussions
+    about: Discuss questions, ideas etc. and share resources related to the library.
+  - name: Shopify React Native Open Source Discord
+    url: https://discord.com/channels/928252803867107358/928253059375726622
+    about: Chat with other community members in the react-native-performance channel on Shopify React Native Open Source Discord.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ The `package.json` file contains various scripts for common tasks:
 
 ### Submitting pull requests
 
-Please take some time to correctly fill our [pull request template](https://github.com/Shopify/react-native-performance/blob/main/.github/PULL_REQUEST_TEMPLATE.md) and detail the proposed changes. This will help reviewers to better understand the context of your PR and provide valuable insights.
+Please take some time to correctly fill our [pull request template](https://github.com/Shopify/react-native-performance-open-source/blob/main/.github/PULL_REQUEST_TEMPLATE.md) and detail the proposed changes. This will help reviewers to better understand the context of your PR and provide valuable insights.
 
 When you're sending a pull request:
 

--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ Packages are set up to be compatible with [autolinking](https://github.com/react
 
 | Name | Version |
 | ---- | ------- |
-| [@shopify/flipper-plugin-react-native-performance](/packages/flipper-plugin-react-native-performance) | [0.0.13](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Fflipper-plugin-react-native-performance%400.0.13) |
-| [@shopify/react-native-performance](/packages/react-native-performance) | [3.0.6](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Freact-native-performance%403.0.6) |
-| [@shopify/react-native-performance-lists-profiler](/packages/react-native-performance-lists-profiler) | [0.0.11](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Freact-native-performance-lists-profiler%400.0.11) |
-| [@shopify/react-native-performance-navigation](/packages/react-native-performance-navigation) | [2.0.9](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Freact-native-performance-navigation%402.0.9) |
-| [@shopify/react-native-performance-navigation-bottom-tabs](/packages/react-native-performance-navigation-bottom-tabs) | [2.0.6](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Freact-native-performance-navigation-bottom-tabs%402.0.6) |
-| [@shopify/react-native-performance-navigation-drawer](/packages/react-native-performance-navigation-drawer) | [2.0.7](https://github.com/Shopify/react-native-performance/releases/tag/%40shopify%2Freact-native-performance-navigation-drawer%402.0.7) |
+| [@shopify/flipper-plugin-react-native-performance](/packages/flipper-plugin-react-native-performance) | [0.0.13](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Fflipper-plugin-react-native-performance%400.0.13) |
+| [@shopify/react-native-performance](/packages/react-native-performance) | [3.0.6](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Freact-native-performance%403.0.6) |
+| [@shopify/react-native-performance-lists-profiler](/packages/react-native-performance-lists-profiler) | [0.0.11](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Freact-native-performance-lists-profiler%400.0.11) |
+| [@shopify/react-native-performance-navigation](/packages/react-native-performance-navigation) | [2.0.9](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Freact-native-performance-navigation%402.0.9) |
+| [@shopify/react-native-performance-navigation-bottom-tabs](/packages/react-native-performance-navigation-bottom-tabs) | [2.0.6](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Freact-native-performance-navigation-bottom-tabs%402.0.6) |
+| [@shopify/react-native-performance-navigation-drawer](/packages/react-native-performance-navigation-drawer) | [2.0.7](https://github.com/Shopify/react-native-performance-open-source/releases/tag/%40shopify%2Freact-native-performance-navigation-drawer%402.0.7) |
 
 ## Playground app
 

--- a/documentation/docs/decisions/data-operations.md
+++ b/documentation/docs/decisions/data-operations.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 #### 22nd February, 2022
 
-When changing the inner workings of state machine in [this](https://github.com/Shopify/react-native-performance/pull/336) PR, we have had issues with migrating `usePromiseProfiler` and the other derived hooks like `useBuildProfiledAPI`, `useProfiledApolloClient`, and `useProfileStaticAsyncStorage`.
+When changing the inner workings of state machine we have had issues with migrating `usePromiseProfiler` and the other derived hooks like `useBuildProfiledAPI`, `useProfiledApolloClient`, and `useProfileStaticAsyncStorage`.
 
 These hooks are tied to a given screen and their timestamps are bundled inside the screen's state as well as in reports. This makes a strong coupling between the `Promise`s these hooks profile and the screen lifecycle.
 

--- a/documentation/docs/decisions/split-common-operations.md
+++ b/documentation/docs/decisions/split-common-operations.md
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 #### November 11, 2021
 
-Teams have reported that in order to use `react-native-performance-common-operations` they need to install dependencies they actually do not use - such as Shop [having to install](https://github.com/Shopify/react-native-performance/issues/91) `@react-navigation/drawer` even though it is not used anywhere in that repo.
+Teams have reported that in order to use `react-native-performance-common-operations` they need to install dependencies they actually do not use. For example, you might need to `@react-navigation/drawer` even though it is not used anywhere in the app.
 
 To mitigate this issue, we have decided to split `react-native-performance-common-operations` into multiple packages:
 
@@ -15,5 +15,3 @@ To mitigate this issue, we have decided to split `react-native-performance-commo
 - `react-native-performance-navigation-bottom-tabs`
 - `react-native-performance-async-storage`
 - `react-native-performance-apollo`
-
-You can read more about the decision [here](https://github.com/Shopify/react-native-performance/issues/175).

--- a/documentation/docs/fundamentals/debugging.md
+++ b/documentation/docs/fundamentals/debugging.md
@@ -15,7 +15,7 @@ The performance library produces two error types:
 
 Only `fatal` errors make it to the error handler and get thrown to the app and (possibly) to the error dashboard. Those errors are legit and should be actionable. You can learn more about `fatal` errors [here](../errors).
 
-Internal `bug` errors signalize that something goes wrong or there is an unhandled flow that the library doesn't support yet. They will be shown when you are in **DEBUG** mode. When you stumble upon a `bug` error, we kindly ask you to [report an issue](https://github.com/Shopify/react-native-performance/issues/new), so we can look into it.
+Internal `bug` errors signalize that something goes wrong or there is an unhandled flow that the library doesn't support yet. They will be shown when you are in **DEBUG** mode. When you stumble upon a `bug` error, we kindly ask you to [report an issue](https://github.com/Shopify/react-native-performance-open-source/issues/new), so we can look into it.
 
 ## Logger
 

--- a/documentation/docs/fundamentals/stubbing-in-test.md
+++ b/documentation/docs/fundamentals/stubbing-in-test.md
@@ -36,5 +36,5 @@ Additionally, the library exposes a mock file that can be imported in your jest 
 
 ```ts
 // in your jest config file
-import '@shopify/react-native-performance/jest-mock';
+import '@shopify/react-native-performance-open-source/jest-mock';
 ```

--- a/documentation/docs/guides/errors.md
+++ b/documentation/docs/guides/errors.md
@@ -30,4 +30,4 @@ Read more about measuring render times [here](fundamentals/measuring-render-time
 
 ### UnsupportedNavigatorError
 
-If you use `react-native-performance-navigation`, this package has `react-navigation` as its dependency. We currently support only navigators of types `stack`, `tab`, `drawer` and so if there is a new navigator that you would need support for, please [create a new Github issue](https://github.com/Shopify/react-native-performance/issues/new).
+If you use `react-native-performance-navigation`, this package has `react-navigation` as its dependency. We currently support only navigators of types `stack`, `tab`, `drawer` and so if there is a new navigator that you would need support for, please [create a new Github issue](https://github.com/Shopify/react-native-performance-open-source/issues/new).

--- a/documentation/docs/known-issues.md
+++ b/documentation/docs/known-issues.md
@@ -21,5 +21,3 @@ If you use a [bottom tab](https://reactnavigation.org/docs/bottom-tab-navigator)
   />
 </Tab.Navigator>
 ```
-
-The bug is tracked in [this](https://github.com/Shopify/react-native-performance/issues/118) issue.

--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -61,7 +61,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/shopify/react-native-performance/edit/main/docs/',
+          editUrl: 'https://github.com/shopify/react-native-performance-open-source/edit/main/documentation/',
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/Shopify/react-native-performance.git"
   },
   "bugs": {
-    "url": "https://github.com/Shopify/react-native-performance/issues"
+    "url": "https://github.com/Shopify/react-native-performance-open-source/issues"
   },
   "publishConfig": {
     "access": "restricted"

--- a/packages/react-native-performance-lists-profiler/package.json
+++ b/packages/react-native-performance-lists-profiler/package.json
@@ -16,7 +16,7 @@
     "test": "tsc -b && yarn jest"
   },
   "bugs": {
-    "url": "https://github.com/shopify/react-native-performance/issues"
+    "url": "https://github.com/shopify/react-native-performance-open-source/issues"
   },
   "homepage": "https://github.com/shopify/react-native-performance#readme",
   "repository": {

--- a/packages/react-native-performance-navigation-bottom-tabs/package.json
+++ b/packages/react-native-performance-navigation-bottom-tabs/package.json
@@ -16,7 +16,7 @@
     "test": "tsc -b && yarn jest"
   },
   "bugs": {
-    "url": "https://github.com/shopify/react-native-performance/issues"
+    "url": "https://github.com/shopify/react-native-performance-open-source/issues"
   },
   "homepage": "https://github.com/shopify/react-native-performance#readme",
   "repository": {

--- a/packages/react-native-performance-navigation-drawer/package.json
+++ b/packages/react-native-performance-navigation-drawer/package.json
@@ -16,7 +16,7 @@
     "test": "tsc -b && yarn jest"
   },
   "bugs": {
-    "url": "https://github.com/shopify/react-native-performance/issues"
+    "url": "https://github.com/shopify/react-native-performance-open-source/issues"
   },
   "homepage": "https://github.com/shopify/react-native-performance#readme",
   "repository": {

--- a/packages/react-native-performance-navigation/package.json
+++ b/packages/react-native-performance-navigation/package.json
@@ -16,7 +16,7 @@
     "test": "tsc -b && yarn jest"
   },
   "bugs": {
-    "url": "https://github.com/shopify/react-native-performance/issues"
+    "url": "https://github.com/shopify/react-native-performance-open-source/issues"
   },
   "homepage": "https://github.com/shopify/react-native-performance#readme",
   "repository": {

--- a/packages/react-native-performance-navigation/src/ReactNavigationPerformanceView.tsx
+++ b/packages/react-native-performance-navigation/src/ReactNavigationPerformanceView.tsx
@@ -70,7 +70,6 @@ export const ReactNavigationPerformanceView = (props: Props) => {
   // This is to avoid emitting reports of render passes where user has not explicitly changed it.
   // `PerformanceMeasureView` will log a reused `renderPassName`
   // and subsequent render passes with a different `renderPassName` will still be reported.
-  // Check out this link for more details: https://github.com/Shopify/react-native-performance/pull/363
   if (shouldReportTransitionEnd) {
     renderProps.current = { renderPassName: TRANSITION_END, interactive };
   } else if (lastRenderPassName.current !== props.renderPassName) {

--- a/packages/react-native-performance/CHANGELOG.md
+++ b/packages/react-native-performance/CHANGELOG.md
@@ -176,7 +176,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   - You would not be getting render pass reports even when the screen successfully renders.
   - When navigating to a different screen, you might have been getting errors saying
     "The navigation for one screen was already queued up..."
-  - https://github.com/Shopify/react-native-performance/pull/57/
 
 ## [1.1.3] - 2021-03-23
 
@@ -185,7 +184,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
   even when the profiler is disabled.
   - The library does not actively support RNWeb, but setting `enabled={false}`
     in that environment should gracefully mimic the absence of the library.
-  - https://github.com/Shopify/react-native-performance/pull/53/
 
 ## [1.1.2] - 2021-03-18
 

--- a/packages/react-native-performance/jest-mock.ts
+++ b/packages/react-native-performance/jest-mock.ts
@@ -5,6 +5,6 @@
  *
  * ```ts
  * // in MyScreen.test.ts
- * import '@shopify/react-native-performance/mock'
+ * import '@shopify/react-native-performance-open-source/mock'
  * ```
  */

--- a/packages/react-native-performance/package.json
+++ b/packages/react-native-performance/package.json
@@ -16,7 +16,7 @@
     "test": "tsc -b && yarn jest"
   },
   "bugs": {
-    "url": "https://github.com/shopify/react-native-performance/issues"
+    "url": "https://github.com/shopify/react-native-performance-open-source/issues"
   },
   "homepage": "https://github.com/shopify/react-native-performance#readme",
   "repository": {

--- a/packages/react-native-performance/src/context/PerformanceProfiler.tsx
+++ b/packages/react-native-performance/src/context/PerformanceProfiler.tsx
@@ -56,7 +56,7 @@ const PerformanceProfiler = ({
         // and we want to save them from that complexity.
         if (error instanceof PerformanceProfilerError && error.type === "bug") {
           logger.error(
-            `You have hit an internal error, please report this: https://github.com/Shopify/react-native-performance/issues/new\n` +
+            `You have hit an internal error, please report this: https://github.com/Shopify/react-native-performance-open-source/issues/new\n` +
               `${error.name}: ${error.message}`
           );
         } else {

--- a/templates/README_ROOT.hbs.md
+++ b/templates/README_ROOT.hbs.md
@@ -34,7 +34,7 @@ Packages are set up to be compatible with [autolinking](https://github.com/react
 | Name | Version |
 | ---- | ------- |
 {{#each packages}}
-| [@shopify/{{name}}](/packages/{{name}}) | [{{version}}](https://github.com/Shopify/react-native-performance/releases/tag/{{releaseTag}}) |
+| [@shopify/{{name}}](/packages/{{name}}) | [{{version}}](https://github.com/Shopify/react-native-performance-open-source/releases/tag/{{releaseTag}}) |
 {{/each}}
 
 ## Playground app


### PR DESCRIPTION
## What

Replaces `@shopify/react-native-performance` repo name with `@shopify/react-native-performance-open-source`