### PR TITLE
fix(drawer): fix documentation link for the react-native-performance-navigation-drawer package

### DIFF
--- a/packages/react-native-performance-navigation-drawer/README.md
+++ b/packages/react-native-performance-navigation-drawer/README.md
@@ -4,4 +4,5 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 
 ## Usage & installation
 
-Please refer to [documentation](https://react-native-performance.docs.shopify.io/guides/react-native-performance-navigation/drawer) to see more information and usage examples.
+Please refer to [documentation](https://react-native-performance.docs.shopify.io/guides/react-native-performance-navigation/react-native-performance-navigation-drawer) to see more information and usage examples.
+


### PR DESCRIPTION
**Motivation**

The current documentation link for the React-Navigation-Drawer is broken and it leads to a 404 page.

## Description

Updates the documentation URL link to match the existing microsite address.

### Test plan

Pressing the link on the mardown file should suffice.

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
- [ ] I have added a changelog entry following the [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) guidelines.
