### PR TITLE
ci: add steps to bundle and build iOS and Android fixture apps

### DIFF
--- a/.github/workflows/react-native-performance.yml
+++ b/.github/workflows/react-native-performance.yml
@@ -73,3 +73,77 @@ jobs:
         run: |
           yarn
           yarn test --forceExit
+  metro-ios:
+    name: "Metro bundling for iOS"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: |
+          yarn
+          yarn build
+          cd fixture
+          yarn
+          mkdir -p /tmp/artifacts
+          yarn react-native bundle --entry-file index.js --platform ios --bundle-output /tmp/artifacts/bundle.js --sourcemap-output /tmp/artifacts/output.map
+  metro-android:
+    name: "Metro bundling for Android"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: |
+          cd fixture
+          yarn
+          cd android
+          mkdir -p /tmp/artifacts
+          ./gradlew bundleDebugJsAndAssets
+  build-ios:
+    name: "Build iOS"
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: ruby setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - run: |
+          bundle install
+          cd fixture
+          yarn
+          cd ios
+          bundle exec pod install
+          mkdir -p /tmp/artifacts
+          set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build -scheme ReactNativePerformanceFixture -workspace ReactNativePerformanceFixture.xcworkspace -destination 'platform=iOS Simulator,name=iPhone 11,OS=latest' | tee /tmp/artifacts/ios_build.log
+      - name: Archive iOS build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: ios-build-artifacts
+          path: /tmp/artifacts
+  build-android:
+    name: "Build Android"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: ruby setup
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+      - run: |
+          bundle install
+          cd fixture
+          yarn
+          cd android
+          ./gradlew assembleDebug

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Description

CI pipeline is missing steps to check successful bundling building of the fixture app. This PR adds these steps to the pipeline.

### Test plan

Confirm CI being happy and 🟢

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
