### PR TITLE
fix: fixed an issue with pull-to-refresh not working on Performance Screen example

### DIFF
--- a/fixture/src/examples/PerformanceScreen.tsx
+++ b/fixture/src/examples/PerformanceScreen.tsx
@@ -96,11 +96,14 @@ const PerformanceScreen = () => {
 
   const onFakePullToRefresh = useCallback(
     async (uiEvent: NativeSyntheticEvent<NativeTouchEvent>) => {
-      resetFlow({uiEvent, destination: NavigationKeys.PERFORMANCE});
+      resetFlow({uiEvent, destination: NavigationKeys.PERFORMANCE, renderTimeoutMillisOverride: 6 * 1000});
       restartTimer();
+      setSimulatedSlowData(undefined);
       rickAndMortyQueryResult.refetch();
+      const data = await simulatedSlowOperation();
+      setSimulatedSlowData(data);
     },
-    [resetFlow, restartTimer, rickAndMortyQueryResult],
+    [resetFlow, restartTimer, rickAndMortyQueryResult, simulatedSlowOperation],
   );
 
   return (


### PR DESCRIPTION
There is bug on fixture's Performance Screen example with pull-to-refresh button not working. See the recording: 

https://user-images.githubusercontent.com/6910688/174302080-859e457c-0825-4f1c-8bbd-8eb105755073.mov

## Description

This PR fixes the issue by updating `onFakePullToRefresh` method - `simulatedSlowData` wasn't updated so the screen got stuck in a rendered state.

### Test plan

- run the app using this branch
- go to `Performance screen`
- wait for it to get rendered
- press `pull-to-refresh` button
- confirm that the countdown on the screen runs again, and you see the appropriate logs in the console.

https://user-images.githubusercontent.com/6910688/174302482-72994ac5-f896-4e8e-ae67-dd333042e41d.mov

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
