### PR TITLE
fix: wrong documentation url lead to page not found

### DIFF
--- a/packages/flipper-plugin-react-native-performance/README.md
+++ b/packages/flipper-plugin-react-native-performance/README.md
@@ -4,4 +4,4 @@ Desktop Flipper plugin for [@shopify/react-native-performance-lists-profiler](/p
 
 ## Usage & installation
 
-Please refer to [documentation](https://shopify.github.io/react-native-performance/guides/react-native-performance-lists-profiler) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-lists-profiler/) to see more information and usage examples.

--- a/packages/react-native-performance-lists-profiler/README.md
+++ b/packages/react-native-performance-lists-profiler/README.md
@@ -4,4 +4,4 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 
 ## Usage & installation
 
-Please refer to [documentation](https://shopify.github.io/react-native-performance/guides/react-native-performance-lists-profiler) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-lists-profiler/) to see more information and usage examples.

--- a/packages/react-native-performance-navigation-bottom-tabs/README.md
+++ b/packages/react-native-performance-navigation-bottom-tabs/README.md
@@ -4,4 +4,4 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 
 ## Usage & installation
 
-Please refer to [documentation](https://shopify.github.io/react-native-performance/guides/react-native-performance-navigation/react-native-performance-navigation-bottom-tabs) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-navigation/react-native-performance-navigation-bottom-tabs) to see more information and usage examples.

--- a/packages/react-native-performance-navigation-drawer/README.md
+++ b/packages/react-native-performance-navigation-drawer/README.md
@@ -4,4 +4,4 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 
 ## Usage & installation
 
-Please refer to [documentation](shopify.github.io/react-native-performance/guides/react-native-performance-navigation/drawer) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-navigation/react-native-performance-navigation-drawer) to see more information and usage examples.

--- a/packages/react-native-performance-navigation/README.md
+++ b/packages/react-native-performance-navigation/README.md
@@ -4,4 +4,4 @@ This package contains some additional higher-order profilers that we anticipate 
 
 ## Usage & installation
 
-Please refer to [documentation](https://shopify.github.io/react-native-performance/guides/react-native-performance-navigation/getting-started) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/guides/react-native-performance-navigation/getting-started) to see more information and usage examples.

--- a/packages/react-native-performance/README.md
+++ b/packages/react-native-performance/README.md
@@ -4,4 +4,4 @@ A library for measuring the render times for the different flows in your app.
 
 ## Usage & installation
 
-Please refer to [documentation](https://shopify.github.io/react-native-performance/fundamentals/getting-started) to see more information and usage examples.
+Please refer to [documentation](https://shopify.github.io/react-native-performance/docs/fundamentals/getting-started) to see more information and usage examples.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request:  -->

**Motivation**

page not found when clicking documentation url on readme.md

## Description

Fixes (issue #)

user can redirect to the right documentation page. add `/docs/` to the url.

### Test plan

click the documentation url

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
