### PR TITLE
Fix profiling FlashList blank area

### DIFF
--- a/packages/react-native-performance-lists-profiler/android/src/main/kotlin/com/shopify/reactnativeperformancelistsprofiler/FlashListPerformanceViewManager.kt
+++ b/packages/react-native-performance-lists-profiler/android/src/main/kotlin/com/shopify/reactnativeperformancelistsprofiler/FlashListPerformanceViewManager.kt
@@ -40,8 +40,8 @@ class FlashListPerformanceViewManager: ReactViewManager() {
                     emptyArray()
                 } else {
                     val container = ((scrollView as ViewGroup).getChildAt(0) as ViewGroup)
-                    val autoLayoutView = (container.getChildAt(0) as ViewGroup)
-                    autoLayoutView.getChildren() + container.getChildren().filter { it.javaClass.name != "AutoLayoutView" }
+                    val autoLayoutView = (container.getChildren().first { it.javaClass.name.endsWith("AutoLayoutView") } as ViewGroup)
+                    autoLayoutView.getChildren() + container.getChildren().filter { it.javaClass.name.endsWith("AutoLayoutView") }
                 }
             }
         }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request:  -->

**Motivation**

Currently, measuring blank area on Android does not work since `FlashListPerformanceViewManager` expects `AutoLayout` to be the only child of `container` – however, it now contains also the header and footer.

## Description

Updated the code for `getCell` to find `AutoLayoutView` properly.

<!--
Please include a summary of what you want to achieve in this pull request. Remember to indicate the affected package(s).
-->

### Test plan

You can test this in the fixture of [flash-list](https://github.com/Shopify/flash-list). On Android, you should now see blank areas shown.

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [x] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation
