### PR TITLE
docs: fixed yarn instructions and copy/paste to be correct

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,9 +9,8 @@ This website is built using [Docusaurus 2](https://docusaurus.io/) and is publis
 Note: make sure you are in the `documentation` folder prior to performing the commands below
 
 ```bash
-dev up        # installs the dependencies
-dev server    # builds the website and serves it locally
-dev open      # opens the website on a browser
+yarn install        # installs the dependencies
+yarn start  # builds and serves the local content
 ```
 
 You should then have a local development server up and running and the website open in browser window. Most changes are reflected live without having to restart the server.
@@ -19,7 +18,8 @@ You should then have a local development server up and running and the website o
 ## Build
 
 ```bash
-dev build     # builds a production version of the website
+yarn build     # builds a production version of the website
+yarn serve    # Serves from the "build" directory
 ```
 
 This command generates static content into the `build` directory and serves it locally for testing.

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,8 +9,8 @@ This website is built using [Docusaurus 2](https://docusaurus.io/) and is publis
 Note: make sure you are in the `documentation` folder prior to performing the commands below
 
 ```bash
-yarn install        # installs the dependencies
-yarn start  # builds and serves the local content
+yarn install # installs the dependencies
+yarn start   # builds and serves the local content
 ```
 
 You should then have a local development server up and running and the website open in browser window. Most changes are reflected live without having to restart the server.

--- a/docs/docs/fundamentals/getting-started.md
+++ b/docs/docs/fundamentals/getting-started.md
@@ -9,13 +9,13 @@ slug: /fundamentals/getting-started
 You can install the package by running the following command:
 
 ```bash
-$ yarn add @shopify/react-native-performance
+yarn add @shopify/react-native-performance
 ```
 
 Since this package contains code that needs to be natively linked, you'll have to run pod install:
 
 ```bash
-$ npx pod-install
+npx pod-install
 ```
 
 ## Usage

--- a/docs/docs/guides/react-native-performance-lists-profiler.md
+++ b/docs/docs/guides/react-native-performance-lists-profiler.md
@@ -14,7 +14,7 @@ This library contains components for profiling [`FlatList`](https://reactnative.
 You can install the package by running the following command:
 
 ```bash
-$ yarn add @shopify/react-native-performance-lists-profiler react-native-flipper
+yarn add @shopify/react-native-performance-lists-profiler react-native-flipper
 ```
 
 ## ListsProfiler

--- a/docs/docs/guides/react-native-performance-navigation/getting-started.md
+++ b/docs/docs/guides/react-native-performance-navigation/getting-started.md
@@ -24,13 +24,13 @@ Note that there are additional helper packages to be used with the [React Naviga
 You can install the package by running the following command:
 
 ```bash
-$ yarn add @shopify/react-native-performance-navigation
+yarn add @shopify/react-native-performance-navigation
 ```
 
 Note that this package has the following peer dependencies that should be listed in your app's package.json:
 
 ```bash
-$ yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @shopify/react-native-performance
+yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @shopify/react-native-performance
 ```
 
 ### ReactNavigationPerformanceView

--- a/docs/docs/guides/react-native-performance-navigation/react-native-performance-navigation-bottom-tabs.md
+++ b/docs/docs/guides/react-native-performance-navigation/react-native-performance-navigation-bottom-tabs.md
@@ -13,13 +13,13 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 You can install the package by running the following command:
 
 ```bash
-$ yarn add @shopify/react-native-performance-navigation-bottom-tabs
+yarn add @shopify/react-native-performance-navigation-bottom-tabs
 ```
 
 Note that this package has the following peer dependencies that should be listed in your app's package.json:
 
 ```bash
-$ yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @react-navigation/bottom-tabs @shopify/react-native-performance @shopify/react-native-performance-navigation
+yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @react-navigation/bottom-tabs @shopify/react-native-performance @shopify/react-native-performance-navigation
 ```
 
 ## Usage

--- a/docs/docs/guides/react-native-performance-navigation/react-native-performance-navigation-drawer.md
+++ b/docs/docs/guides/react-native-performance-navigation/react-native-performance-navigation-drawer.md
@@ -13,13 +13,13 @@ Extension library atop [@shopify/react-native-performance-navigation](../react-n
 You can install the package by running the following command:
 
 ```bash
-$ yarn add @shopify/react-native-performance-navigation-drawer
+yarn add @shopify/react-native-performance-navigation-drawer
 ```
 
 Note that this package has the following peer dependencies that should be listed in your app's package.json:
 
 ```bash
-$ yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @react-navigation/drawer-tabs @shopify/react-native-performance @shopify/react-native-performance-navigation react-native-reanimated react-native-gesture-handler
+yarn add @react-navigation/core @react-navigation/stack @react-navigation/native @react-navigation/drawer-tabs @shopify/react-native-performance @shopify/react-native-performance-navigation react-native-reanimated react-native-gesture-handler
 ```
 
 ## Usage


### PR DESCRIPTION
The docs have "$" signs for prompts which unfortunately get copied as part of the command (when you hover over the text and press the Copy button). For almost all users, this wouldn't be the desired behavior (i.e. you don't want the $ as part of the command you paste).

Tiny change, hope it helps someone.

I also fixed the seemingly-incorrect instructions in the docs README, and updated them to use `yarn` as well as to refer to `yarn start` vs. `yarn serve` at the correct times.