### PR TITLE
fix: load auto-generated Swift import header correctly

### DIFF
--- a/packages/react-native-performance/ios/ReactNativePerformance/ReactNativePerformance.m
+++ b/packages/react-native-performance/ios/ReactNativePerformance/ReactNativePerformance.m
@@ -1,5 +1,5 @@
 #import "ReactNativePerformance.h"
-#import "ReactNativePerformance-Swift.h"
+#import <ReactNativePerformance/ReactNativePerformance-Swift.h>
 
 static NSTimeInterval startupTimestamp = -1.0;
 


### PR DESCRIPTION
**Motivation**

Project wasn't building successfully in Xcode. (See #117)

## Description

Fixes (#117). The import location is not correct for modern versions of Xcode, which otherwise fail to find the auto-generated Swift header.

### Test plan

1. `yarn test`
2. Install, build, and run package within another project

## Checklist

- [ ] I have added a decision record entry, PR includes changes to monorepo setup that may require explanation