### PR TITLE
Fix flipper id change

### DIFF
--- a/fixture/package.json
+++ b/fixture/package.json
@@ -16,7 +16,6 @@
     "@react-navigation/drawer": "6.4.1",
     "@react-navigation/native": "6.0.10",
     "@react-navigation/stack": "6.2.1",
-    "@shopify/flipper-plugin-react-native-performance": "1.0.1",
     "@shopify/react-native-performance": "4.1.2",
     "@shopify/react-native-performance-lists-profiler": "1.1.0",
     "@shopify/react-native-performance-navigation": "3.0.0",

--- a/packages/react-native-performance-lists-profiler/src/ListsProfiler.tsx
+++ b/packages/react-native-performance-lists-profiler/src/ListsProfiler.tsx
@@ -7,7 +7,7 @@ import ListsProfilerProps from './ListsProfilerProps';
 const bootstrapPlugin = (): Promise<Flipper.FlipperConnection> => {
   return new Promise(resolve => {
     addPlugin({
-      getId: () => '@shopify/react-native-performance',
+      getId: () => 'shopify-react-native-performance',
       onConnect: connection => {
         return resolve(connection);
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3394,13 +3394,6 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/flipper-plugin-react-native-performance@1.0.1":
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/@shopify/flipper-plugin-react-native-performance/-/flipper-plugin-react-native-performance-1.0.1.tgz#8d4f8f329c4568fad4c08a612789378fd47ae027"
-  integrity sha512-Ep1HxiT93W9IFa5vXnOB1dBpahCGWImLWYX9b6yJ6Z0UMnGIGLExAIJJkik78ah6g+12Q9b2QtVWwInl94DE6g==
-  dependencies:
-    recharts "^2.1.8"
-
 "@sideway/address@^4.1.3":
   version "4.1.4"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.4.tgz#03dccebc6ea47fdc226f7d3d1ad512955d4783f0"


### PR DESCRIPTION
**Motivation**

Fix latest flipper plugin not working

## Description

The Flipper plugin ID was changed in https://github.com/Shopify/react-native-performance/pull/95, but the actual value returned by getId was not, resulting in the renamed plugin not working. I update to the correct ID defined here: https://github.com/Shopify/react-native-performance/blob/main/packages/flipper-plugin-react-native-performance/package.json#L4

Also, I remove the old plugin reference from the fixture so the issue is easier to catch (the new plugin version is already there)

### Test plan

<!-- Describe the steps to test this change so that a reviewer can verify it. -->
- [ ] Works locally with 2.0.0 plugin

## Checklist

<!--- Please, make sure that when doing "Squash and rebase" or "Rebase and merge", the commit adheres to [conventional commits](https://github.com/Shopify/react-native-packages/blob/main/.github/CONTRIBUTING.md#conventional-commits) guideline -->
- [ ] ~~I have added a decision record entry, PR includes changes to monorepo setup that may require explanation~~