### PR TITLE
rammatical issue in the last step

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,4 +3,4 @@
 Releases **are done by Shopify engineers** following the steps below:
 
 1. Run `yarn release`. This command will prompt you to update all the modules which have been touched since the last change. We try to keep the `main` branch always shippable. So all packages that have pending changes since the last release should be shipped simultaneously. To which versions the packages should be bumped will be automatically selected by `lerna`. Changelogs will be updated by `lerna` automatically as well.
-2. Follow to the registry and deploy the package.
+2. Go to the registry and deploy the package.


### PR DESCRIPTION
There is a slight grammatical issue in the last step. "Follow to the registry and deploy the package." should be corrected to:

👉 "Go to the registry and deploy the package."

